### PR TITLE
Close #33 upgrade to spree 4.5 and ruby 3.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,12 +10,15 @@
 coverage
 default
 Gemfile.lock
+yarn.lock
 tmp
 nbproject
 pkg
 *.sw?
 spec/dummy
 .rvmrc
+.nvmrc
+.tool-versions
 .sass-cache
 public/spree
 .ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 gem 'spree', github: 'spree/spree', branch: 'main'
 gem 'rails-controller-testing'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'main'
-gem 'spree_reviews', github: 'spree/spree_reviews'
+gem 'spree_reviews', github: 'bookmebus/spree_reviews', branch: 'update-spree-450'
 gem 'byebug'
 
 gemspec

--- a/app/controllers/spree/api/v2/storefront/feedback_reviews_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/feedback_reviews_controller.rb
@@ -17,7 +17,7 @@ module Spree
             else
               render_error_payload(feedback_review.errors.full_messages.join(", "))
             end
-            
+
           end
 
           private
@@ -30,12 +30,8 @@ module Spree
             @review = Spree::Review.find(params[:review_id])
           end
 
-          def permitted_feedback_review_attributes
-            [:rating, :comment]
-          end
-      
           def feedback_review_params
-            params.require(:feedback_review).permit(permitted_feedback_review_attributes)
+            params.require(:feedback_review).permit(Spree::PermittedAttributes.feedback_review_attributes)
           end
 
           def sanitize_rating

--- a/app/controllers/spree/api/v2/storefront/reviews_controller.rb
+++ b/app/controllers/spree/api/v2/storefront/reviews_controller.rb
@@ -9,10 +9,10 @@ module Spree
           def collection
             reviews = @product.reviews.approved.includes(review_includes)
             reviews = params[:oldest] == '1' ? reviews.oldest_first : reviews.most_recent_first
-            
+
             reviews
           end
-          
+
           def create
             params[:review][:rating].sub!(/\s*[^0-9]*\z/, '') unless params[:review][:rating].blank?
             params[:review][:show_identifier] = params[:review][:show_identifier].to_i == 1
@@ -53,14 +53,9 @@ module Spree
             results.concat([:feedback_reviews]) if params[:with_feedback] == '1'
             results
           end
-          
 
-          def permitted_review_attributes
-            [:rating, :title, :review, :name, :show_identifier]
-          end
-      
           def review_params
-            params.require(:review).permit(permitted_review_attributes)
+            params.require(:review).permit(Spree::PermittedAttributes.review_attributes)
           end
         end
       end

--- a/app/models/spree_reviews_api/spree/feedback_review_decorator.rb
+++ b/app/models/spree_reviews_api/spree/feedback_review_decorator.rb
@@ -22,4 +22,4 @@ module SpreeReviewsApi
   end
 end
 
-::Spree::FeedbackReview.prepend(SpreeReviewsApi::Spree::FeedbackReviewDecorator)
+Spree::FeedbackReview.prepend(SpreeReviewsApi::Spree::FeedbackReviewDecorator) if Spree::FeedbackReview.included_modules.exclude?(SpreeReviewsApi::Spree::FeedbackReviewDecorator)

--- a/app/models/spree_reviews_api/spree/review_decorator.rb
+++ b/app/models/spree_reviews_api/spree/review_decorator.rb
@@ -15,9 +15,9 @@ module SpreeReviewsApi
 
         save
       end
-      
+
     end
   end
 end
 
-::Spree::Review.prepend(SpreeReviewsApi::Spree::ReviewDecorator)
+::Spree::Review.prepend(SpreeReviewsApi::Spree::ReviewDecorator) if Spree::Review.included_modules.exclude?(SpreeReviewsApi::Spree::ReviewDecorator)

--- a/lib/spree_reviews_api.rb
+++ b/lib/spree_reviews_api.rb
@@ -1,4 +1,5 @@
 require 'spree_core'
+require 'spree_api'
 require 'spree_extension'
 require 'spree_reviews_api/engine'
 require 'spree_reviews_api/version'

--- a/lib/spree_reviews_api/engine.rb
+++ b/lib/spree_reviews_api/engine.rb
@@ -10,7 +10,7 @@ module SpreeReviewsApi
     end
 
     initializer 'spree_reviews_api.environment', before: :load_config_initializers do |_app|
-      SpreeReviewsApi::Config = SpreeReviewsApi::Configuration.new
+      Config = Configuration.new
     end
 
     def self.activate

--- a/spec/controllers/spree/api/v2/storefront/feedback_reviews_controller_spec.rb
+++ b/spec/controllers/spree/api/v2/storefront/feedback_reviews_controller_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Spree::Api::V2::Storefront::FeedbackReviewsController, type: :con
     context "with user login and valid data" do
       it 'create feedback review and response success' do
         set_resource_owner_token
-        review = create(:review, user: @oauth_resource_owner)
+
+        review = create(:review, user: create(:user))
         feedback_review_params = {
           rating: 4,
           comment: 'Good service'
@@ -34,12 +35,12 @@ RSpec.describe Spree::Api::V2::Storefront::FeedbackReviewsController, type: :con
         expect(response_body["error"]).to eq "The resource you were looking for could not be found."
       end
     end
-    
+
     context "without user login" do
       it 'response error with status 403' do
         review = create(:review)
         post :create, params: {review_id: review.id}
-        
+
         response_body = JSON.parse(response.body)
 
         expect(response.status).to eq 403

--- a/spec/factories/oauth_access_tokens.rb
+++ b/spec/factories/oauth_access_tokens.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :oauth_access_token, class: Doorkeeper::AccessToken do
+  factory :oauth_access_token, class: Spree::OauthAccessToken do
     sequence(:token) { |n| "token-#{n}" }
 
     # application and resource_owner must be explicitly specified

--- a/spec/factories/oauth_applications.rb
+++ b/spec/factories/oauth_applications.rb
@@ -1,6 +1,6 @@
 
 FactoryBot.define do
-  factory :oauth_application, class: Doorkeeper::Application do
+  factory :oauth_application, class: Spree::OauthApplication do
     sequence(:name) { |n| "Name-#{n}" }
     confidential { true }
     redirect_uri { 'urn:ietf:wg:oauth:2.0:oob' }

--- a/spec/support/doorkeeper_auth_helper.rb
+++ b/spec/support/doorkeeper_auth_helper.rb
@@ -4,7 +4,7 @@ module DoorkeeperAuthHelper
     @oauth_resource_owner = create(:user)
     @oauth_access_token = create(:oauth_access_token,
                                   application: @oauth_application,
-                                  resource_owner_id: @oauth_resource_owner.id )
+                                  resource_owner: @oauth_resource_owner)
     @oauth_access_token
   end
 

--- a/spree_reviews_api.gemspec
+++ b/spree_reviews_api.gemspec
@@ -21,12 +21,14 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '>= 3.2.0', '< 5.0'
+  spree_version = '>= 4.5'
+  s.add_dependency 'spree', spree_version
   s.add_dependency 'spree_core', spree_version
   s.add_dependency 'spree_api', spree_version
   s.add_dependency 'spree_backend', spree_version
-  s.add_dependency 'spree_reviews'
   s.add_dependency 'spree_extension'
 
   s.add_development_dependency 'spree_dev_tools'
+  s.add_development_dependency 'byebug'
+  s.add_development_dependency 'pg'
 end


### PR DESCRIPTION
- update spree version to 4.5
- update ruby version to 3.2
- using spree permitted attributes from spree_review gem instead 
- fix doorkeeper factory in rspec since spree version is upgraded
- fix spec

related PR: https://github.com/bookmebus/spree_reviews/pull/1